### PR TITLE
Corrected tns-core-modules dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"@angular/router": "3.0.0-alpha.7",
 		"@angular/router-deprecated": "2.0.0-rc.2",
 		"nativescript-angular": "0.1.8",
-		"tns-core-modules": "^2.1.0"
+		"tns-core-modules": "^2.0.1"
 	},
 	"devDependencies": {
 		"nativescript-dev-typescript": "^0.3.2"


### PR DESCRIPTION
As 2.1.0 version of tns-core-modules does not exist currently, I am not able to create new project using this template. So corrected it.