### PR TITLE
refactor(angular5): Declare the app.module.ngfactory.d.ts generated by ngc with AoT

### DIFF
--- a/app.module.ngfactory.d.ts
+++ b/app.module.ngfactory.d.ts
@@ -1,0 +1,4 @@
+/**
+ * A dynamically generated module when compiled with AoT.
+ */
+export const AppModuleNgFactory: any;

--- a/main.aot.ts
+++ b/main.aot.ts
@@ -1,6 +1,7 @@
 // this import should be first in order to load some required settings (like globals and reflect-metadata)
 import { platformNativeScript } from "nativescript-angular/platform-static";
 
+// "./app.module.ngfactory" is a dynamically generated module when compiled with AoT.
 import { AppModuleNgFactory } from "./app.module.ngfactory";
 
 platformNativeScript().bootstrapModuleFactory(AppModuleNgFactory);


### PR DESCRIPTION
The angular compiler will generate dynamically the app.module.ngfactory.d.ts.
For plain tsc to compile without errors the main.aot.ts should be compiled without errors,
so app.module.ngfactory.d.ts will provide the necessary type information.