### PR TITLE
refactor(deps): remove explicit tns-core-modules dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "dependencies": {
         "nativescript-theme-core": "~1.0.4",
         "nativescript-angular": "~5.2.0",
-        "tns-core-modules": "~3.4.0",
         "@angular/animations": "~5.2.0",
         "@angular/common": "~5.2.0",
         "@angular/compiler": "~5.2.0",


### PR DESCRIPTION
Remove explicit tns-core-modules dependency and let CLI handle it (much like it handles runtime dependencies). In this way in case certain future version of runtime is not compatible with old version of modules, we would not be forced to do a same-day release of tns-core-modules and templates.